### PR TITLE
Remove `\n` in the end of connection string

### DIFF
--- a/instagres.ts
+++ b/instagres.ts
@@ -52,7 +52,7 @@ import pWaitFor from "p-wait-for";
 			);
 			if (!res.ok) return false;
 			return pWaitFor.resolveWith(
-				((await res.json()) as { connectionString: string }).connectionString,
+				((await res.json()) as { connectionString: string }).connectionString.trim(),
 			);
 		},
 		{ before: false, interval: 2000 },


### PR DESCRIPTION
Not sure that I'm making PR to the right repo, but I noticed when I'm copying the connection string, it has `\n` in the end. Would love to trim it.